### PR TITLE
Device capabilities detection

### DIFF
--- a/lib/sonos/device/accessory.rb
+++ b/lib/sonos/device/accessory.rb
@@ -6,15 +6,5 @@ module Sonos::Device
   # Used for non-speaker Sonos devices
   class Accessory < Base
 
-    MODELS = {
-      :'CR100' => 'CR100',   # Released Jan 2005
-      :'CR200' => 'CONTROL', # Released Jul 2009
-      :'WD100' => 'DOCK',
-      :'ZB100' => 'BRIDGE'   # Released Oct 2007
-    }.freeze
-
-    def self.models
-      MODELS
-    end
   end
 end

--- a/lib/sonos/device/base.rb
+++ b/lib/sonos/device/base.rb
@@ -12,13 +12,10 @@ module Sonos::Device
       data = retrieve_information(ip)
       model_number = data[:model_number]
 
-      # TODO: Clean up
-      if Accessory.models.keys.include?(model_number.to_sym)
-        Accessory.new(ip, data)
-      elsif Speaker.models.keys.include?(model_number.to_sym)
+      if data[:devices].include?('urn:schemas-upnp-org:device:MediaRenderer:1')
         Speaker.new(ip, data)
       else
-        raise ArgumentError.new("#{data[:model_number]} not supported")
+        Accessory.new(ip, data)
       end
     end
 
@@ -59,7 +56,7 @@ module Sonos::Device
     # Get the device's model
     # @return [String] a string representation of the device's model
     def model
-      self.class.models[@model_number.to_sym]
+      @model_number.to_s
     end
 
     # Can this device play music?
@@ -90,6 +87,8 @@ module Sonos::Device
         zone_type: doc.xpath('/xmlns:root/xmlns:device/xmlns:zoneType').inner_text,
         model_number: doc.xpath('/xmlns:root/xmlns:device/xmlns:modelNumber').inner_text,
         services: doc.xpath('/xmlns:root/xmlns:device/xmlns:serviceList/xmlns:service/xmlns:serviceId').
+          collect(&:inner_text),
+        devices: doc.xpath('/xmlns:root/xmlns:device/xmlns:deviceList/xmlns:device/xmlns:deviceType').
           collect(&:inner_text)
       }
     end

--- a/lib/sonos/device/speaker.rb
+++ b/lib/sonos/device/speaker.rb
@@ -14,22 +14,6 @@ module Sonos::Device
     include Sonos::Endpoint::Alarm
     include Sonos::Features::Voiceover
 
-    MODELS = {
-      :'S1'    => 'PLAY:1',     # Released Oct 2013
-      :'S3'    => 'PLAY:3',     # Released Jul 2011
-      :'S5'    => 'PLAY:5',     # Released Nov 2009
-      :'S9'    => 'PLAYBAR',    # Released Feb 2013
-      :'Sub'   => 'SUB',        # Released May 2012
-      :'ZP80'  => 'ZP80',       # Released Apr 2006
-      :'ZP90'  => 'CONNECT',    # Released Aug 2008
-      :'ZP100' => 'ZP100',      # Released Jan 2005
-      :'ZP120' => 'CONNECT:AMP' # Released Aug 2008
-    }.freeze
-
-    def self.models
-      MODELS
-    end
-
     def speaker?
       services.include?('urn:upnp-org:serviceId:MusicServices')
     end


### PR DESCRIPTION
Resend of this PR. Uses data in the device XML to detect if something is a speaker, rather than having to maintain a list of known products.