### PR TITLE
Filter SSDP responses to only accept Sonos responses

### DIFF
--- a/lib/sonos/discovery.rb
+++ b/lib/sonos/discovery.rb
@@ -27,7 +27,7 @@ module Sonos
     # Look for Sonos devices on the network and return the first IP address found
     # @return [String] the IP address of the first Sonos device found
     def discover
-      result = SSDP::Consumer.new.search(service: 'urn:schemas-upnp-org:device:ZonePlayer:1', first_only: true, timeout: @timeout)
+      result = SSDP::Consumer.new.search(service: 'urn:schemas-upnp-org:device:ZonePlayer:1', first_only: true, timeout: @timeout, filter: lambda {|r| r[:params]["ST"].match(/ZonePlayer/) })
       @first_device_ip = result[:address]
     end
 


### PR DESCRIPTION
I was having an issue where my Phillips HUE hub was responding to the SSDP search. This patch filters SSDP responses to more narrowly accept Sonos device responses.